### PR TITLE
feat: implement collision detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ version = "0.1.0"
 dependencies = [
  "benimator",
  "bevy",
+ "impacted",
 ]
 
 [[package]]
@@ -1416,6 +1417,7 @@ checksum = "e4fa84eead97d5412b2a20aed4d66612a97a9e41e08eababdb9ae2bf88667490"
 dependencies = [
  "bytemuck",
  "mint",
+ "num-traits",
  "serde",
 ]
 
@@ -1592,6 +1594,20 @@ dependencies = [
  "num-traits",
  "png",
  "scoped_threadpool",
+]
+
+[[package]]
+name = "impacted"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686d3bbf97757c990b27f232e896b8e330ba52b554d0f212b869759aef8422dd"
+dependencies = [
+ "bevy_ecs",
+ "bevy_transform",
+ "glam",
+ "rustc_version 0.4.0",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -1776,6 +1792,12 @@ name = "libm"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libudev-sys"
@@ -2131,6 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm 0.2.2",
 ]
 
 [[package]]
@@ -2481,7 +2504,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.6",
 ]
 
 [[package]]
@@ -2530,6 +2562,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "semver-parser"
@@ -2645,7 +2683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "stdweb-derive",
@@ -2696,7 +2734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0dc6d20ce137f302edf90f9cd3d278866fd7fb139efca6f246161222ad6d87"
 dependencies = [
  "lazy_static",
- "libm",
+ "libm 0.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 bevy = "0.6"
 benimator = "2.0"
+impacted = { version = "1.3", features = ["bevy-06"] }

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -1,0 +1,22 @@
+use crate::AppState;
+use bevy::prelude::*;
+use impacted::CollisionShape;
+
+pub struct CollisionPlugin;
+
+impl Plugin for CollisionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_system_set(
+            SystemSet::on_update(AppState::Game).with_system(update_collision_transforms),
+        );
+    }
+}
+
+fn update_collision_transforms(
+    mut shapes: Query<(&mut CollisionShape, &GlobalTransform), Changed<GlobalTransform>>,
+) {
+    // Iterate through all collision shapes and set transform accordingly
+    for (mut shape, transform) in shapes.iter_mut() {
+        shape.set_transform(*transform);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::type_complexity)]
 
 mod camera;
+mod collision;
 mod enemy;
 mod menu;
 mod player;
@@ -12,6 +13,7 @@ use benimator::AnimationPlugin;
 use bevy::prelude::*;
 
 use camera::CameraPlugin;
+use collision::CollisionPlugin;
 use enemy::EnemyPlugin;
 use menu::MenuPlugin;
 use player::PlayerPlugin;
@@ -40,6 +42,7 @@ fn main() {
         .add_plugin(MenuPlugin)
         .add_plugin(AnimationPlugin::default())
         .add_plugin(CameraPlugin)
+        .add_plugin(CollisionPlugin)
         .add_plugin(EnemyPlugin)
         .add_plugin(PlayerPlugin)
         .add_plugin(WorldPlugin)


### PR DESCRIPTION
This PR introduces basic infrastructure for collision detection. A new dependency, `impacted`, has been added to streamline the collision detection process.

Currently, a simple message is printed when the player collides with an enemy.