### PR TITLE
feat: introduce retry state and menu

### DIFF
--- a/src/level_select.rs
+++ b/src/level_select.rs
@@ -1,6 +1,6 @@
 use crate::{
     ui::{spawn_back_button, GameFont},
-    world::World,
+    world::GameWorld,
     AppState,
 };
 use bevy::prelude::*;
@@ -160,7 +160,7 @@ fn manage_level_select_buttons(
         // Check if the button has been clicked
         if matches!(interaction, Interaction::Clicked) {
             commands.insert_resource(
-                World::load_level(&level_select_button.level_path, level_select_button.level)
+                GameWorld::load_level(&level_select_button.level_path, level_select_button.level)
                     .unwrap(),
             );
             state.set(AppState::Game).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod level_select;
 mod menu;
 mod player;
 mod pursue;
+mod retry;
 mod ui;
 mod upgrade_select;
 mod upgrades;
@@ -35,6 +36,7 @@ pub enum AppState {
     Help,
     Game,
     Death,
+    Retry,
 }
 
 pub fn despawn_all(mut commands: Commands, entities: Query<Entity>) {
@@ -51,7 +53,7 @@ fn main() {
         .add_system_set(SystemSet::on_exit(AppState::UpgradeSelect).with_system(despawn_all))
         .add_system_set(SystemSet::on_exit(AppState::LevelSelect).with_system(despawn_all))
         .add_system_set(SystemSet::on_exit(AppState::Help).with_system(despawn_all))
-        .add_system_set(SystemSet::on_exit(AppState::Death).with_system(despawn_all))
+        .add_system_set(SystemSet::on_exit(AppState::Retry).with_system(despawn_all))
         .add_plugin(AnimationPlugin::default())
         .add_plugin(CameraPlugin)
         .add_plugin(CollisionPlugin)

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -12,7 +12,7 @@ pub struct MenuPlugin;
 impl Plugin for MenuPlugin {
     fn build(&self, app: &mut App) {
         app.add_system_set(SystemSet::on_enter(AppState::Menu).with_system(create_menu))
-            .add_system_set(SystemSet::on_update(AppState::Menu).with_system(manage_menu_button));
+            .add_system_set(SystemSet::on_update(AppState::Menu).with_system(manage_menu_buttons));
     }
 }
 
@@ -168,7 +168,7 @@ fn create_menu(
         });
 }
 
-fn manage_menu_button(
+fn manage_menu_buttons(
     mut state: ResMut<State<AppState>>,
     interaction: Query<(&Interaction, &ButtonType), (Changed<Interaction>, With<Button>)>,
 ) {

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,137 @@
+use crate::{ui::GameFont, AppState};
+use bevy::prelude::*;
+
+pub struct RetryPlugin;
+
+impl Plugin for RetryPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_system_set(SystemSet::on_enter(AppState::Retry).with_system(create_retry_menu))
+            .add_system_set(
+                SystemSet::on_update(AppState::Retry).with_system(manage_retry_buttons),
+            );
+    }
+}
+
+#[derive(Component)]
+enum ButtonType {
+    Retry,
+    Menu,
+}
+
+fn create_retry_menu(mut commands: Commands, font: Res<GameFont>) {
+    commands.spawn_bundle(UiCameraBundle::default());
+
+    commands
+        .spawn_bundle(NodeBundle {
+            style: Style {
+                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::FlexEnd,
+                ..Style::default()
+            },
+            color: Color::NONE.into(),
+            ..NodeBundle::default()
+        })
+        .with_children(|parent| {
+            // Spawn upgrade select title
+            parent.spawn_bundle(TextBundle {
+                style: Style {
+                    position_type: PositionType::Absolute,
+                    position: Rect {
+                        top: Val::Percent(5.0),
+                        ..Rect::default()
+                    },
+                    ..Style::default()
+                },
+                text: Text::with_section(
+                    "You died",
+                    TextStyle {
+                        font: font.get_handle(),
+                        font_size: 90.0,
+                        ..TextStyle::default()
+                    },
+                    TextAlignment::default(),
+                ),
+                ..TextBundle::default()
+            });
+
+            parent
+                .spawn_bundle(ButtonBundle {
+                    style: Style {
+                        position_type: PositionType::Absolute,
+                        position: Rect {
+                            top: Val::Percent(40.0),
+                            ..Rect::default()
+                        },
+                        size: Size::new(Val::Px(300.0), Val::Px(65.0)),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..Style::default()
+                    },
+                    ..ButtonBundle::default()
+                })
+                .insert(ButtonType::Retry)
+                .with_children(|parent| {
+                    parent.spawn_bundle(TextBundle {
+                        text: Text::with_section(
+                            "Retry",
+                            TextStyle {
+                                font: font.get_handle(),
+                                font_size: 60.0,
+                                color: Color::BLACK,
+                            },
+                            TextAlignment::default(),
+                        ),
+                        ..TextBundle::default()
+                    });
+                });
+
+            parent
+                .spawn_bundle(ButtonBundle {
+                    style: Style {
+                        position_type: PositionType::Absolute,
+                        position: Rect {
+                            top: Val::Percent(60.0),
+                            ..Rect::default()
+                        },
+                        size: Size::new(Val::Px(300.0), Val::Px(65.0)),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..Style::default()
+                    },
+                    ..ButtonBundle::default()
+                })
+                .insert(ButtonType::Menu)
+                .with_children(|parent| {
+                    parent.spawn_bundle(TextBundle {
+                        text: Text::with_section(
+                            "Main Menu",
+                            TextStyle {
+                                font: font.get_handle(),
+                                font_size: 60.0,
+                                color: Color::BLACK,
+                            },
+                            TextAlignment::default(),
+                        ),
+                        ..TextBundle::default()
+                    });
+                });
+        });
+}
+
+fn manage_retry_buttons(
+    mut state: ResMut<State<AppState>>,
+    interaction: Query<(&Interaction, &ButtonType), (Changed<Interaction>, With<Button>)>,
+) {
+    for (interaction, button_type) in interaction.iter() {
+        match (interaction, button_type) {
+            (Interaction::Clicked, ButtonType::Retry) => {
+                state.set(AppState::Game).unwrap();
+            }
+            (Interaction::Clicked, ButtonType::Menu) => {
+                state.set(AppState::Menu).unwrap();
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,4 +1,8 @@
-use crate::{ui::GameFont, AppState};
+use crate::{
+    ui::GameFont,
+    world::{GameWorld, WorldType},
+    AppState,
+};
 use bevy::prelude::*;
 
 pub struct RetryPlugin;
@@ -120,12 +124,18 @@ fn create_retry_menu(mut commands: Commands, font: Res<GameFont>) {
 }
 
 fn manage_retry_buttons(
+    mut commands: Commands,
     mut state: ResMut<State<AppState>>,
+    world: Res<GameWorld>,
     interaction: Query<(&Interaction, &ButtonType), (Changed<Interaction>, With<Button>)>,
 ) {
     for (interaction, button_type) in interaction.iter() {
         match (interaction, button_type) {
             (Interaction::Clicked, ButtonType::Retry) => {
+                if let WorldType::Level { index, path } = &world.world_type {
+                    commands.insert_resource(GameWorld::load_level(path, *index).unwrap());
+                }
+
                 state.set(AppState::Game).unwrap();
             }
             (Interaction::Clicked, ButtonType::Menu) => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,6 +2,7 @@ use crate::{
     help::HelpPlugin,
     level_select::LevelSelectPlugin,
     menu::MenuPlugin,
+    retry::RetryPlugin,
     upgrade_select::{UpgradeButton, UpgradeSelectPlugin},
     AppState,
 };
@@ -47,6 +48,9 @@ impl Plugin for UiPlugin {
                 SystemSet::on_update(AppState::Help)
                     .with_system(manage_button_colors)
                     .with_system(manage_back_button),
+            )
+            .add_system_set(
+                SystemSet::on_update(AppState::Retry).with_system(manage_button_colors),
             );
     }
 }
@@ -60,6 +64,7 @@ impl PluginGroup for UiPlugins {
             .add(MenuPlugin)
             .add(UpgradeSelectPlugin)
             .add(HelpPlugin)
+            .add(RetryPlugin)
             .add(UiPlugin);
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -11,11 +11,11 @@ use std::{
     f32::consts::PI,
     fs::File,
     io::{self, BufRead, BufReader},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
-enum WorldType {
-    Level(usize),
+pub enum WorldType {
+    Level { index: usize, path: PathBuf },
     Endless,
 }
 
@@ -49,15 +49,15 @@ impl Tile {
     const SIZE: f32 = 24.0;
 }
 
-pub struct World {
-    world_type: WorldType,
+pub struct GameWorld {
+    pub world_type: WorldType,
     // Coordinates of the player's spawn location: (x, y)
     player_start_coordinates: (usize, usize),
     layout: Vec<Vec<Option<Tile>>>,
 }
 
-impl World {
-    pub fn load_level<P: AsRef<Path>>(path: P, level: usize) -> io::Result<Self> {
+impl GameWorld {
+    pub fn load_level(path: &Path, index: usize) -> io::Result<Self> {
         // Open file and collect rows
         let file = File::open(path)?;
         let lines: Vec<io::Result<String>> = BufReader::new(file).lines().collect();
@@ -87,7 +87,10 @@ impl World {
         }
 
         Ok(Self {
-            world_type: WorldType::Level(level),
+            world_type: WorldType::Level {
+                index,
+                path: path.into(),
+            },
             player_start_coordinates: start.unwrap_or((0, 0)),
             layout,
         })
@@ -105,7 +108,7 @@ impl Plugin for WorldPlugin {
 
 fn spawn_world(
     mut commands: Commands,
-    world: Res<World>,
+    world: Res<GameWorld>,
     mut animations: ResMut<Assets<SpriteSheetAnimation>>,
     mut textures: ResMut<Assets<TextureAtlas>>,
     asset_server: Res<AssetServer>,


### PR DESCRIPTION
This PR adds a way to transition from the `Death` state by introducing a `Retry` state.
In this new `Retry` state, the player has the option to either retry or go back to the menu.

![image](https://user-images.githubusercontent.com/43205692/156411298-ebc6c6b8-2b85-414d-a605-79d5f13fc53f.png)
